### PR TITLE
remove outdated modules which broke sms

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,10 +19,10 @@
   ],
   "dependencies": {
     "async": "*",
-    "body-parser": "^1.9.2",
-    "express": "^4.10.1",
+    "body-parser": "*",
+    "express": "*",
     "marked": "*",
-    "mongojs": "^0.15.1",
+    "mongojs": "*",
     "express-session": "*",
     "basic-auth-connect": "*",
     "serve-favicon": "*",


### PR DESCRIPTION
I tested the modules and there is no need to use outdated node modules. Actually mongojs version 0.15.1 broke sms and it did not run.
