### PR TITLE
This solves "Issue 44", where get_sensors returned "No measurements found" if there were no sensors.

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -572,7 +572,7 @@ function get_sensors(req, callback) {
     db[collection_sensors].find(query).sort({ ts: -1 }).toArray(function (err, res) {
         if (err) return callback(err);
 		else if (res.length == 0)
-            callback({ error: "No measurements found.", status: 404 });
+            callback({ error: "No sensors found.", status: 404 });
         else
 			callback(res);
     });


### PR DESCRIPTION
Now the message is changed to "No sensors found.", when there are no sensors found in the database.
